### PR TITLE
Getting images in a jupyter widget without failing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A project for generating and testing circuits",
     "main": "src/gui/main.js",
     "scripts": {
-        "test": "mocha --require tests/setup.js 'tests/**/*.test.js'",
+        "test": "cp src/gui/renderers/GetImage.js src/gui/renderers/origGetImage.js && cp tests/testGetImage.js src/gui/renderers/GetImage.js && mocha --require tests/setup.js 'tests/**/*.test.js' && mv src/gui/renderers/origGetImage.js src/gui/renderers/GetImage.js",
         "bundle": "esbuild src/gui/main.js --minify --format=esm --bundle --outdir=dist/static --asset-names=assets/[name] --loader:.png=dataurl",
         "copy": "cp -r assets dist/assets && cp src/gui/gui.html dist/",
         "build": "npm run bundle && npm run copy",

--- a/src/gui/renderers/GetImage.js
+++ b/src/gui/renderers/GetImage.js
@@ -1,11 +1,51 @@
-import RUrl from '../../../assets/R.png';
-import CUrl from '../../../assets/C.png';
+import C from '../../../assets/C.png';
+import C_hover from '../../../assets/C_hover.png';
+import C_hover_selected from '../../../assets/C_hover_selected.png';
+import C_selected from '../../../assets/C_selected.png';
+import G from '../../../assets/G.png';
+import G_hover from '../../../assets/G_hover.png';
+import G_hover_selected from '../../../assets/G_hover_selected.png';
+import G_selected from '../../../assets/G_selected.png';
+import J from '../../../assets/J.png';
+import J_hover from '../../../assets/J_hover.png';
+import J_hover_selected from '../../../assets/J_hover_selected.png';
+import J_selected from '../../../assets/J_selected.png';
+import L from '../../../assets/L.png';
+import L_hover from '../../../assets/L_hover.png';
+import L_hover_selected from '../../../assets/L_hover_selected.png';
+import L_selected from '../../../assets/L_selected.png';
+import R from '../../../assets/R.png';
+import R_hover from '../../../assets/R_hover.png';
+import R_hover_selected from '../../../assets/R_hover_selected.png';
+import R_selected from '../../../assets/R_selected.png';
+
 
 export function GetImage(type) {
-    if (type === 'R.png') {
-        return RUrl;
-    } else if (type === 'C.png') {
-        return CUrl;
+    const imageMap = {
+        'C.png': C,
+        'C_hover.png': C_hover,
+        'C_hover_selected.png': C_hover_selected,
+        'C_selected.png': C_selected,
+        'G.png': G,
+        'G_hover.png': G_hover,
+        'G_hover_selected.png': G_hover_selected,
+        'G_selected.png': G_selected,
+        'J.png': J,
+        'J_hover.png': J_hover,
+        'J_hover_selected.png': J_hover_selected,
+        'J_selected.png': J_selected,
+        'L.png': L,
+        'L_hover.png': L_hover,
+        'L_hover_selected.png': L_hover_selected,
+        'L_selected.png': L_selected,
+        'R.png': R,
+        'R_hover.png': R_hover,
+        'R_hover_selected.png': R_hover_selected,
+        'R_selected.png': R_selected
+    };
+    
+    if (imageMap[type]) {
+        return imageMap[type];
     } else {
         throw new Error(`Unknown type: ${type}`);
     }

--- a/src/gui/renderers/GetImage.js
+++ b/src/gui/renderers/GetImage.js
@@ -1,0 +1,12 @@
+import RUrl from '../../../assets/R.png';
+import CUrl from '../../../assets/C.png';
+
+export function GetImage(type) {
+    if (type === 'R.png') {
+        return RUrl;
+    } else if (type === 'C.png') {
+        return CUrl;
+    } else {
+        throw new Error(`Unknown type: ${type}`);
+    }
+}

--- a/src/gui/renderers/ResistorRenderer.js
+++ b/src/gui/renderers/ResistorRenderer.js
@@ -1,11 +1,12 @@
 import { ElementRenderer } from "./ElementRenderer.js";
 import { Position } from "../../domain/valueObjects/Position.js";
+import { GetImage } from "./GetImage.js";
 
 export class ResistorRenderer extends ElementRenderer {
   constructor(context) {
     super(context);
     this.image = new Image();
-    this.image.src = new URL("../../../assets/R.png", import.meta.url).href;
+    this.image.src = GetImage("R.png");
     this.imageLoaded = false;
 
     this.image.onload = () => {

--- a/tests/testGetImage.js
+++ b/tests/testGetImage.js
@@ -1,0 +1,7 @@
+export function GetImage(type) {
+    // Concatenate '../../../assets/' and type
+    const imagePath = `../../../assets/${type}`;
+
+    // Return the full URL to the image
+    return new URL(imagePath, import.meta.url).href;
+}


### PR DESCRIPTION
This is related to issue #36.

The problem it solves is:
Jupyter Notebook widget needs images to be in lined (no references).
esbuild does this if you use the syntax:
import myimg from './assets/myimg.png';
mocha testing however will not accept this syntax .

This is a very hacky fix, that replaces GetImage.js with the
URL(imagePath, import.meta.url).href;
syntax before testing and restoring the ‘import’ syntax after testing.

Works for:
1)	widget
2)	stand-alone
3)	testing

The Copilot generated solution to issue #36 is more elegant, very complicated and I’m not convinced it will solve the problem addressed here.

I suggest we go with this hacky solution until we can come up with a better idea, that works for all 3 cases.
